### PR TITLE
Add alpha beta pruning

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,19 +1,25 @@
-use super::board::{Board, State, Mark};
-
+use super::board::{Board, Mark, State};
+use std::cmp;
+use std::time::Instant;
 pub struct OptimalAi;
 
 impl OptimalAi {
     fn opposite(mark: Mark) -> Mark {
-        if mark == Mark::Cross { Mark::Nought } else { Mark::Cross }
+        if mark == Mark::Cross {
+            Mark::Nought
+        } else {
+            Mark::Cross
+        }
     }
 
     pub fn make_move(board: &mut Board, ai_mark: Mark) {
+        let now = Instant::now();
         let mut best_score = -999;
         let mut best_index = 0;
 
         for index in board.get_free_cells() {
             board.set_cell(ai_mark, index);
-            let score = OptimalAi::minimax(board, false, ai_mark);
+            let score = OptimalAi::minimax(board, -999, 999, false, ai_mark);
             board.clear_cell(index);
 
             if score > best_score {
@@ -23,21 +29,24 @@ impl OptimalAi {
         }
 
         board.set_cell(ai_mark, best_index);
+        println!(
+            "Took {} milliseconds taken to choose move!",
+            now.elapsed().as_millis()
+        );
     }
 
-    pub fn minimax(board: &mut Board, maximising: bool, ai_mark: Mark) -> i32 {
+    pub fn minimax(
+        board: &mut Board,
+        mut alpha: i32,
+        mut beta: i32,
+        maximising: bool,
+        ai_mark: Mark,
+    ) -> i32 {
         let state = board.get_state();
         let opp_mark = OptimalAi::opposite(ai_mark);
 
         match state {
-            State::Win(mark) => {
-                if mark == ai_mark {
-                    return 1;
-                }
-                else {
-                    return -1;
-                }
-            },
+            State::Win(mark) => return if mark == ai_mark { 1 } else { -1 },
             State::Draw => return 0,
             State::Unfinished => (),
         };
@@ -45,12 +54,26 @@ impl OptimalAi {
         let mut final_score = if maximising { -999 } else { 999 };
 
         for index in board.get_free_cells() {
-            board.set_cell(if maximising {ai_mark} else {opp_mark}, index);
-            let score = OptimalAi::minimax(board, !maximising, ai_mark);
+            board.set_cell(if maximising { ai_mark } else { opp_mark }, index);
+
+            let score = OptimalAi::minimax(board, alpha, beta, !maximising, ai_mark);
+
             board.clear_cell(index);
 
-            if maximising && score > final_score || !maximising && score < final_score {
-                final_score = score;
+            if maximising {
+                final_score = cmp::max(final_score, score);
+                alpha = cmp::max(alpha, final_score);
+
+                if beta <= final_score {
+                    break;
+                }
+            } else {
+                final_score = cmp::min(final_score, score);
+                beta = cmp::min(beta, final_score);
+
+                if alpha >= final_score {
+                    break;
+                }
             }
         }
         final_score

--- a/src/board.rs
+++ b/src/board.rs
@@ -42,7 +42,7 @@ impl Board {
             if free_board & 1 << i != 0 {
                 free_cells.push(i);
             }
-        };
+        }
 
         free_cells
     }
@@ -60,11 +60,17 @@ impl Board {
         ];
 
         for mask in win_masks {
-            if self.cross_layer & mask == mask { return State::Win(Mark::Cross); }
-            if self.nought_layer & mask == mask { return State::Win(Mark::Nought); }
+            if self.cross_layer & mask == mask {
+                return State::Win(Mark::Cross);
+            }
+            if self.nought_layer & mask == mask {
+                return State::Win(Mark::Nought);
+            }
         }
 
-        if self.cross_layer | self.nought_layer == 0b111_111_111 { return State::Draw; }
+        if self.cross_layer | self.nought_layer == 0b111_111_111 {
+            return State::Draw;
+        }
 
         State::Unfinished
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-mod board;
 mod ai;
+mod board;
 
-use board::{Board, Mark, State};
 use ai::OptimalAi;
+use board::{Board, Mark, State};
 
 use std::io::{self, Write};
 
@@ -13,9 +13,7 @@ fn handle_user_move(board: &mut Board, mark: Mark) {
 
         print!("Enter a number: ");
 
-        io::stdout()
-            .flush()
-            .expect("Error flushing output");
+        io::stdout().flush().expect("Error flushing output");
 
         io::stdin()
             .read_line(&mut choice)
@@ -23,8 +21,12 @@ fn handle_user_move(board: &mut Board, mark: Mark) {
 
         let index: u32 = match choice.trim().parse() {
             Ok(num) => {
-                if num <= 8 && valid_choices.contains(&num) { num } else { continue }
-            },
+                if num <= 8 && valid_choices.contains(&num) {
+                    num
+                } else {
+                    continue;
+                }
+            }
             Err(_) => continue,
         };
 
@@ -37,7 +39,6 @@ fn main() {
     let mut game_board = Board::default();
 
     while game_board.get_state() == State::Unfinished {
-
         println!("{}", game_board);
         handle_user_move(&mut game_board, Mark::Cross);
 
@@ -50,5 +51,4 @@ fn main() {
 
     println!("{}", game_board);
     println!("Result: {:?}", game_board.get_state());
-
 }


### PR DESCRIPTION
This pull request adds alpha-beta pruning to the minimax algorithm. This reduces the time needed from, on average, 188ms to around 20ms. this isn't the perfect x^(1/2) reduction that perfect alpha-beta pruning has, but instead around x^(1.7) which is still good.